### PR TITLE
Gear work

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -26,6 +26,7 @@ SHEETS
         compute Bulky et al (skill + gear combO) and pass to roll formula
       GEAR
         GEAR SHEET
+          pocket size defaults to 1, needs to be "not pocketable"
           isPhysical not implemented
           need a way to assign an item to a slot
           gear description owner is already draggable - i need to make events to receive the drop

--- a/TODO.txt
+++ b/TODO.txt
@@ -23,9 +23,13 @@ SHEETS
     pocket defaults to 0, should be true or whatever
     PLAYER CHARACTER
       SKILLS
-        pass/fails are getting saved to the actor, not the item (old data? make a new actor)
         compute Bulky et al (skill + gear combO) and pass to roll formula
       GEAR
+        GEAR SHEET
+          isPhysical not implemented
+          need a way to assign an item to a slot
+          gear description owner is already draggable - i need to make events to receive the drop
+        can't seem to have 2 of the same item?
         how do i account for gear assigned to the actor not already displayed in the inventory?
         how to represent containers? should they be their own item type?
           from discord:

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -318,7 +318,7 @@
   "TB2.GearBookNameLabel": "Book",
   "TB2.GearBookPageLabel": "Page",
   "TB2.GearTabContainersHeader": "Containers",
-  "TB2.GearContainedInLabel": "Slot:",
+  "TB2.GearContainedInLabel": "Contained in Slot:",
   "TB2.": "PLACEHOLDER",
   "TB2.": "PLACEHOLDER",
   "TB2.": "PLACEHOLDER",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -319,7 +319,7 @@
   "TB2.GearBookPageLabel": "Page",
   "TB2.GearTabContainersHeader": "Containers",
   "TB2.GearContainedInLabel": "Contained in Slot:",
-  "TB2.": "PLACEHOLDER",
+  "TB2.GearContainedInNothingLabel": " -- select a container slot -- ",
   "TB2.": "PLACEHOLDER",
   "TB2.": "PLACEHOLDER",
   "TB2.": "PLACEHOLDER",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -318,7 +318,7 @@
   "TB2.GearBookNameLabel": "Book",
   "TB2.GearBookPageLabel": "Page",
   "TB2.GearTabContainersHeader": "Containers",
-  "TB2.": "PLACEHOLDER",
+  "TB2.GearContainedInLabel": "Slot:",
   "TB2.": "PLACEHOLDER",
   "TB2.": "PLACEHOLDER",
   "TB2.": "PLACEHOLDER",

--- a/src/module/actor/TBActor.ts
+++ b/src/module/actor/TBActor.ts
@@ -1,12 +1,6 @@
 import { getGame } from '../helpers';
-import { SkillTest } from './TBActorDataProperties';
 import { createTestRoll } from '../rolls/CheckFactory';
-import { TB } from '../config';
-import {
-  ConfiguredDocumentClass,
-  ConstructorDataType,
-  DocumentConstructor,
-} from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes';
+import { SkillTest, SlotType, TB } from '../config';
 
 declare global {
   interface DocumentClassConfig {
@@ -20,11 +14,29 @@ export class TBActor extends Actor {
     this.prepareEmbeddedEntities();
     this.applyActiveEffectsToBaseData();
     this.prepareDerivedData();
+    this.prepareGear();
     this.applyActiveEffectsToDerivedData();
   }
   /** @override */
   prepareBaseData(): void {
-    // this.prepareTests();
+    super.prepareBaseData();
+  }
+
+  prepareGear(): void {
+    const data = this.data.data;
+
+    data.containerSlots = Object.entries(data.containerSlotCapacities)
+      .filter(([slot, capacity]) => {
+        if (typeof capacity === 'boolean') {
+          return capacity;
+        } else {
+          return capacity > 0;
+        }
+      })
+      .map(([slot]) => {
+        // return slot;
+        return 'feet';
+      });
   }
 
   /**

--- a/src/module/actor/TBActor.ts
+++ b/src/module/actor/TBActor.ts
@@ -28,14 +28,13 @@ export class TBActor extends Actor {
     data.containerSlots = Object.entries(data.containerSlotCapacities)
       .filter(([slot, capacity]) => {
         if (typeof capacity === 'boolean') {
-          return capacity;
+          return capacity; // do we have pockets?
         } else {
-          return capacity > 0;
+          return capacity > 0; // the slot has capacity, so include it
         }
       })
       .map(([slot]) => {
-        // return slot;
-        return 'feet';
+        return slot as SlotType;
       });
   }
 

--- a/src/module/actor/TBActorDataProperties.ts
+++ b/src/module/actor/TBActorDataProperties.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { TB } from '../config';
+import { SkillTest, SlotType, TB } from '../config';
 import { ModifiableDataBaseTotal } from '../common/CommonData';
 import { CharacterDataSource, NpcDataSourceData } from './TBActorDataSource';
 
@@ -40,19 +40,21 @@ interface HasMight {
 // how many slots and of what type they contain. or, actor item slots represent _capacity_, and
 // item inventory slots represent volume against that capacity.
 export interface HasInventorySlots {
-  containerSlots: {
-    pack: number;
-    held: number;
-    belt: number;
-    torso: number;
+  containerSlotCapacities: {
     head: number;
-    hand: number;
+    belt: number;
     feet: number;
+    hand: number;
+    held: number;
     neck: number;
-    arm: number;
+    pack: number;
     // as pockets are effectively infinite, this represents the capability to have item slots at all
     pocket: boolean;
+    torso: number;
+    custom: number;
   };
+  // should contain any slot type with capacity greater than zero
+  containerSlots: SlotType[];
 }
 
 type TBActorDataPropertiesDataAttributes = {
@@ -66,9 +68,6 @@ type TBActorDataPropertiesDataTraits = {
 type TBActorDataPropertiesDataChecks = {
   [key in SkillTest]: number;
 };
-
-export type SkillTest = keyof typeof TB.i18n.skills;
-export type SlotType = keyof typeof TB.i18n.slots;
 
 export function isTest(value: string): value is SkillTest {
   return Object.keys(TB.i18n.skills).includes(value);

--- a/src/module/actor/sheets/TBActorSheet.ts
+++ b/src/module/actor/sheets/TBActorSheet.ts
@@ -313,7 +313,9 @@ export class TBActorSheet extends ActorSheet<ActorSheet.Options, TBActorSheetDat
     logger.info('in onChangeEmbeddedDocument');
     event.preventDefault();
     const element = $(event.currentTarget).get(0);
-    enforce(element instanceof HTMLInputElement);
+    const isValid: boolean =
+      element instanceof HTMLInputElement || element instanceof HTMLSelectElement;
+    enforce(isValid);
     if (element.disabled) return;
 
     const effectElement = element.closest(
@@ -353,6 +355,10 @@ export class TBActorSheet extends ActorSheet<ActorSheet.Options, TBActorSheetDat
       }
       case 'number': {
         const value = Number(element.value.trim());
+        return value;
+      }
+      case 'select-one': {
+        const value = element.value;
         return value;
       }
       default: {

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -204,3 +204,7 @@ export const TB = {
   i18nKeys,
   icons: {},
 };
+
+export const AllSlots: SlotType[] = Object.keys(TB.i18n.slots).map(([slot]) => {
+  return slot as SlotType;
+});

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -188,6 +188,8 @@ const i18nKeys = {
     custom: 'TB2.SlotTypeCustom',
   },
 };
+export type SkillTest = keyof typeof TB.i18n.skills;
+export type SlotType = keyof typeof TB.i18n.slots;
 export const TB = {
   ASCII: String.raw`
 ---------------------------------------------------------------------------------------

--- a/src/module/handlebars/helpers.ts
+++ b/src/module/handlebars/helpers.ts
@@ -1,6 +1,6 @@
 import { TBItem } from '../item/TBItem';
 import { utilities } from '../util/utilities';
-import { SlotType } from '../config';
+import { AllSlots, SlotType, TB } from '../config';
 
 export default function registerHandlebarsHelpers(): void {
   Object.entries(utilities).forEach(([key, helper]) => Handlebars.registerHelper(key, helper));
@@ -13,6 +13,7 @@ const helpers = {
   },
   isEmpty: (input: Array<unknown> | null | undefined): boolean => (input?.length ?? 0) === 0,
   beginnersLuckAttributes: (): string[] => TBItem.beginnersLuckAttributes,
+  allSlots: (): SlotType[] => AllSlots,
   ifIn: (input: Array<unknown> | null | undefined, elem: unknown): boolean =>
     input?.includes(elem) || false,
   times: (input: number, repeatMe: string | null | undefined): string => {

--- a/src/module/handlebars/helpers.ts
+++ b/src/module/handlebars/helpers.ts
@@ -21,6 +21,7 @@ const helpers = {
     return repeatMe?.repeat(input) || '';
   },
   compareItemSlot: (input: SlotType | undefined, slot: SlotType): boolean => {
-    return input === undefined || input === slot;
+    logger.info(`item is in slot ${input}, comparing against ${slot}`);
+    return input !== undefined || input === slot;
   },
 };

--- a/src/module/handlebars/helpers.ts
+++ b/src/module/handlebars/helpers.ts
@@ -22,6 +22,6 @@ const helpers = {
   },
   compareItemSlot: (input: SlotType | undefined, slot: SlotType): boolean => {
     logger.info(`item is in slot ${input}, comparing against ${slot}`);
-    return input !== undefined || input === slot;
+    return input === slot;
   },
 };

--- a/src/module/handlebars/helpers.ts
+++ b/src/module/handlebars/helpers.ts
@@ -1,5 +1,6 @@
 import { TBItem } from '../item/TBItem';
 import { utilities } from '../util/utilities';
+import { SlotType } from '../config';
 
 export default function registerHandlebarsHelpers(): void {
   Object.entries(utilities).forEach(([key, helper]) => Handlebars.registerHelper(key, helper));
@@ -17,5 +18,8 @@ const helpers = {
   times: (input: number, repeatMe: string | null | undefined): string => {
     logger.info(`in times with, repeating ${repeatMe} ${input} times`);
     return repeatMe?.repeat(input) || '';
+  },
+  compareItemSlot: (input: SlotType | undefined, slot: SlotType): boolean => {
+    return input === undefined || input === slot;
   },
 };

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -28,12 +28,19 @@ export function getGameSafe(): Game | undefined {
  * - If `message` is an instance of {@link Error}, it is thrown.
  * - If `message` is `undefined`, an {@link Error} with a default message is thrown.
  */
-export function enforce(value: unknown, message?: string | Error): asserts value {
+export function enforce(
+  value: unknown,
+  message?: string | Error,
+  logToConsole = true,
+): asserts value {
   if (!value) {
     if (!message) {
       message =
         getGameSafe()?.i18n.localize('TB2.ErrorUnexpectedError') ??
         'There was an unexpected error in the Torchbearer 2E system. For more details, please take a look at the console (F12).';
+    }
+    if (logToConsole) {
+      console.log(message);
     }
     throw message instanceof Error ? message : new Error(message);
   }

--- a/src/module/item/ItemDataSource.ts
+++ b/src/module/item/ItemDataSource.ts
@@ -1,5 +1,4 @@
-import { TB } from '../config';
-import { SlotType } from '../actor/TBActorDataProperties';
+import { SlotType, TB } from '../config';
 import { TracksTests } from './ItemDataProperties';
 
 declare global {
@@ -145,7 +144,7 @@ export interface GearDataSourceData extends GMOnly, BookDataSource {
     neck: number;
     pocket: number; // number of items per pocket (don't use this and stackSize)
   };
-  containedIn?: SlotType | undefined;
+  containedIn?: SlotType;
   // the number of items in each instance of the Item (e.g. Torches would be 4, as they are Pack 1 for 4)
   stackSize: number;
 }

--- a/src/module/item/TBItem.ts
+++ b/src/module/item/TBItem.ts
@@ -1,6 +1,6 @@
 import { getGame } from '../helpers';
 import { createTestRoll } from '../rolls/CheckFactory';
-import { TB } from '../config';
+import { SlotType, TB } from '../config';
 import { AttributeType, ClassType, ItemType } from './ItemDataSource';
 import { utilities } from '../util/utilities';
 
@@ -27,6 +27,7 @@ export class TBItem extends Item {
         ? TBItem.classesWithUrdr.includes(this.data.data.classType)
         : false;
     if (this.data.type === 'gear') {
+      this.data.data.containedIn = undefined; // this defaults it to ghost gear
       this.data.data.isContainer = Object.values(this.data.data.capacity).some((slot) => {
         return slot > 0;
       });

--- a/src/module/item/TBItem.ts
+++ b/src/module/item/TBItem.ts
@@ -27,7 +27,10 @@ export class TBItem extends Item {
         ? TBItem.classesWithUrdr.includes(this.data.data.classType)
         : false;
     if (this.data.type === 'gear') {
-      this.data.data.containedIn = undefined; // this defaults it to ghost gear
+      // newly added item
+      if (this.data.data.containedIn === null) {
+        this.data.data.containedIn = undefined; // this moves it to ghost gear
+      }
       this.data.data.isContainer = Object.values(this.data.data.capacity).some((slot) => {
         return slot > 0;
       });

--- a/src/styles/components/_rollable_image.scss
+++ b/src/styles/components/_rollable_image.scss
@@ -24,6 +24,8 @@
   &__image {
     border: none;
     transition: 0.1s ease;
+    height: 24px;
+    width: 24px;
   }
 
   &__overlay {

--- a/src/template.yml
+++ b/src/template.yml
@@ -170,7 +170,7 @@ Item:
     templates:
       - book
     description: 'item description'
-    containedIn: ''
+    containedIn:
     availability: ''
     cost: 0
     volume:

--- a/src/template.yml
+++ b/src/template.yml
@@ -5,7 +5,7 @@ Actor:
     - npc
   templates:
     hasInventorySlots:
-      containerSlots:
+      containerSlotCapacities:
         pack: 0
         held: 2
         belt: 3

--- a/src/templates/sheets/actor/components/rollable-image.hbs
+++ b/src/templates/sheets/actor/components/rollable-image.hbs
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
 --}}
 <div class="tb-rollable-image{{#if rollable}} tb-rollable-image--rollable {{rollableClass}}{{/if}}"
      title="{{#if rollable}}{{rollableTitle}}{{else}}{{title}}{{/if}}">
-  <img class="tb-rollable-image__image" alt="{{alt}}" src="{{src}}" />
+  <img class="tb-rollable-image__image" alt="{{alt}}" src="{{src}}" style="height: 24px; width: 24px" />
   {{#if rollable}}
     <img class="tb-rollable-image__overlay" alt="{{localize 'TB2.DiceOverlayImageAltText'}}"
          src="icons/svg/d20-black.svg" />

--- a/src/templates/sheets/actor/tabs/character-inventory.hbs
+++ b/src/templates/sheets/actor/tabs/character-inventory.hbs
@@ -9,7 +9,6 @@
     <div class="grid grid-8col">
       {{#each config.i18n.slots as |translation name|}}
         {{#if (gt (lookup ../data.data.containerSlots name) 0)}}
-          {{log 'has ' name 'slots:' (lookup ../data.data.containerSlots name) }}
             <h4 class="tb-embedded-document-list-title">{{localize translation}}</h4>
             <ol class="tb-embedded-document-list tb-embedded-document-list--gear item-list">
               {{#each (lookup ../../gearSlotMap name) as |itemData id|}}
@@ -27,8 +26,8 @@
   {{#unless (isEmpty containers)}}
     {{log containers}}
     <div class="grid grid-8col">
-      {{#each containers as |itemData|}}
       <h4 class="tb-embedded-document-list-title">{{localize 'TB2.GearTabContainersHeader'}}</h4>
+      {{#each containers as |itemData|}}
           <ul class="tb-embedded-document-list tb-embedded-document-list--gear item-list">
          {{!--       {{#> systems/torchbearer/templates/sheets/actor/components/item-list-header.hbs}}
             {{/systems/torchbearer/templates/sheets/actor/components/item-list-header.hbs}}
@@ -42,13 +41,14 @@
   {{/unless}}
   {{#unless (isEmpty ghostGear)}}
     <div class="grid grid-8col">
+      <h4 class="tb-embedded-document-list-title">{{localize 'TB2.GearTabUnassignedGearHeader'}}</h4>
       {{#each ghostGear as |itemData|}}
-        <h4 class="tb-embedded-document-list-title">{{localize 'TB2.GearTabUnassignedGearHeader'}}</h4>
         <ul class="tb-embedded-document-list tb-embedded-document-list--gear item-list">
-         {{!-- {{#> systems/torchbearer/templates/sheets/actor/components/item-list-header.hbs}}
+         {{#> systems/torchbearer/templates/sheets/actor/components/item-list-header.hbs}}
           {{/systems/torchbearer/templates/sheets/actor/components/item-list-header.hbs}}
           {{> systems/torchbearer/templates/sheets/actor/components/item-list-entry.hbs
-            itemData=itemData}} --}}
+            itemData=itemData
+            isPhysical=true}}
         </ul>
       {{/each}}
     </div>

--- a/src/templates/sheets/actor/tabs/character-inventory.hbs
+++ b/src/templates/sheets/actor/tabs/character-inventory.hbs
@@ -46,9 +46,28 @@
         <ul class="tb-embedded-document-list tb-embedded-document-list--gear item-list">
          {{#> systems/torchbearer/templates/sheets/actor/components/item-list-header.hbs}}
           {{/systems/torchbearer/templates/sheets/actor/components/item-list-header.hbs}}
-          {{> systems/torchbearer/templates/sheets/actor/components/item-list-entry.hbs
+          {{#> systems/torchbearer/templates/sheets/actor/components/item-list-entry.hbs
             itemData=itemData
             isPhysical=true}}
+            {{log "itemData:" itemData}}
+              <div class="side-property">
+                <label for="data.containedIn-{{itemData._id}}">{{localize 'TB2.GearContainedInLabel'}}</label>
+                <select id="data.containedIn-{{itemData._id}}"
+                        name="data.containedIn"
+                        class="change-item"
+                        data-property="containedIn" data-dtype="SlotType">
+                  <option disabled {{#if (isEmpty itemData.data.containedIn)}}selected{{/if}}>{{localize "TB2.GearContainedInNothingLabel"}}</option>
+                  {{#select itemData.data.containedIn}}
+                    {{#each ../../actor.data.data.containerSlots as |slotKey slotIdx|}}
+                      {{log "slotKey:" slotKey}}
+                      <option value="{{slotKey}}"
+                              {{#if (compareItemSlot itemData.data.containedIn slotKey)}}selected{{/if}}
+                      >{{localize slotKey}}</option>
+                    {{/each}}
+                  {{/select}}
+                </select>
+              </div>
+          {{/systems/torchbearer/templates/sheets/actor/components/item-list-entry.hbs}}
         </ul>
       {{/each}}
     </div>

--- a/src/templates/sheets/actor/tabs/character-inventory.hbs
+++ b/src/templates/sheets/actor/tabs/character-inventory.hbs
@@ -8,15 +8,39 @@
     <hr>
     <div class="grid grid-8col">
       {{#each config.i18n.slots as |translation name|}}
-        {{#if (gt (lookup ../data.data.containerSlots name) 0)}}
+<!--        {{log "iteration slot:" name}}-->
+<!--        {{log "lookup of slot:" (ifIn ../data.data.containerSlots name)}}-->
+        {{#if (ifIn ../data.data.containerSlots name)}}
+<!--          {{log "slot has slots"}}-->
             <h4 class="tb-embedded-document-list-title">{{localize translation}}</h4>
             <ol class="tb-embedded-document-list tb-embedded-document-list--gear item-list">
-              {{#each (lookup ../../gearSlotMap name) as |itemData id|}}
+              {{#each (lookup ../gearSlotMap name) as |itemData id|}}
+                {{log "in slots, item is" itemData}}
                 {{#> systems/torchbearer/templates/sheets/actor/components/item-list-header.hbs}}
-                  <div>Item: {{localize translation}}</div>
                 {{/systems/torchbearer/templates/sheets/actor/components/item-list-header.hbs}}
-                {{> systems/torchbearer/templates/sheets/actor/components/item-list-entry.hbs
+                {{#> systems/torchbearer/templates/sheets/actor/components/item-list-entry.hbs
                   itemData=itemData}}
+
+                  <div class="side-property">
+                    <label for="data.containedIn-{{itemData._id}}">{{localize 'TB2.GearContainedInLabel'}}</label>
+                    <select id="data.containedIn-{{itemData._id}}"
+                            name="data.containedIn"
+                            class="tb-embedded-document-list__editable change-item"
+                            data-item-id="{{itemData._id}}"
+                            data-property="data.containedIn" data-dtype="String">
+                      <option disabled>{{localize "TB2.GearContainedInNothingLabel"}}</option>
+                      {{log "populating options" ../../../this}}
+                      {{#select ../itemData.data.containedIn}}
+                        {{#each ../../../actor.data.data.containerSlots as |slotKey slotIdx|}}
+                          {{log "selected is" (compareItemSlot ../itemData.data.containedIn slotKey)}}
+                          <option value="{{slotKey}}"
+                          {{#if (compareItemSlot ../itemData.data.containedIn slotKey)}}selected{{/if}}
+                          >{{localize slotKey}}</option>
+                        {{/each}}
+                      {{/select}}
+                    </select>
+                  </div>
+                {{/systems/torchbearer/templates/sheets/actor/components/item-list-entry.hbs}}
               {{/each}}
             </ol>
         {{/if}}

--- a/src/templates/sheets/actor/tabs/character-inventory.hbs
+++ b/src/templates/sheets/actor/tabs/character-inventory.hbs
@@ -54,9 +54,10 @@
                 <label for="data.containedIn-{{itemData._id}}">{{localize 'TB2.GearContainedInLabel'}}</label>
                 <select id="data.containedIn-{{itemData._id}}"
                         name="data.containedIn"
-                        class="change-item"
-                        data-property="containedIn" data-dtype="SlotType">
-                  <option disabled {{#if (isEmpty itemData.data.containedIn)}}selected{{/if}}>{{localize "TB2.GearContainedInNothingLabel"}}</option>
+                        class="tb-embedded-document-list__editable change-item"
+                        data-item-id="{{itemData._id}}"
+                        data-property="data.containedIn"   data-dtype="String">
+                  <option disabled>{{localize "TB2.GearContainedInNothingLabel"}}</option>
                   {{#select itemData.data.containedIn}}
                     {{#each ../../actor.data.data.containerSlots as |slotKey slotIdx|}}
                       {{log "slotKey:" slotKey}}

--- a/src/templates/sheets/actor/tabs/character-inventory.hbs
+++ b/src/templates/sheets/actor/tabs/character-inventory.hbs
@@ -57,13 +57,11 @@
                         class="tb-embedded-document-list__editable change-item"
                         data-item-id="{{itemData._id}}"
                         data-property="data.containedIn"   data-dtype="String">
-                  <option disabled>{{localize "TB2.GearContainedInNothingLabel"}}</option>
+                  <option disabled selected>{{localize "TB2.GearContainedInNothingLabel"}}</option>
                   {{#select itemData.data.containedIn}}
                     {{#each ../../actor.data.data.containerSlots as |slotKey slotIdx|}}
                       {{log "slotKey:" slotKey}}
-                      <option value="{{slotKey}}"
-                              {{#if (compareItemSlot itemData.data.containedIn slotKey)}}selected{{/if}}
-                      >{{localize slotKey}}</option>
+                      <option value="{{slotKey}}">{{localize slotKey}}</option>
                     {{/each}}
                   {{/select}}
                 </select>

--- a/src/templates/sheets/item/components/gear-slots.hbs
+++ b/src/templates/sheets/item/components/gear-slots.hbs
@@ -11,12 +11,12 @@
       name="data.volume.{{name}}"
       value="{{lookup ../data.data.volume name}}">
   {{/each}}
-  <label for="data.stackSize-{{data._id}}">{{localize 'TB2.GearPocketSlotsLabel'}}</label>
+  <label for="data.stackSize">{{localize 'TB2.GearPocketSlotsLabel'}}</label>
   <input
     class="tb-embedded-document-list__editable change-item"
     type="number" data-type="Number"
     title="{{localize 'TB2.GearItemStackSizeSize'}}"
-    name="data.stackSize-{{data._id}}"
+    name="data.stackSize"
     value="{{data.data.volume.stackSize}}">
 </div>
 <div class="form-group grid grid-4col">

--- a/src/templates/sheets/item/gear-sheet.hbs
+++ b/src/templates/sheets/item/gear-sheet.hbs
@@ -1,4 +1,5 @@
 <form class="{{cssClass}}" autocomplete="off">
+  {{log 'gear-sheet.hbs' this}}
   {{#> systems/torchbearer/templates/sheets/item/components/sheet-header.hbs}}
     {{#if editable}}
       editable!
@@ -23,7 +24,9 @@
   <section class="sheet-body">
 
     {{!-- Description Tab --}}
-    {{#> systems/torchbearer/templates/sheets/item/tabs/description.hbs}}
+    {{#> systems/torchbearer/templates/sheets/item/tabs/description.hbs
+      slots=slots
+      isPhysical=true}}
     {{/systems/torchbearer/templates/sheets/item/tabs/description.hbs}}
 
     {{!-- Effects Tab --}}

--- a/src/templates/sheets/item/gear-sheet.hbs
+++ b/src/templates/sheets/item/gear-sheet.hbs
@@ -25,8 +25,23 @@
 
     {{!-- Description Tab --}}
     {{#> systems/torchbearer/templates/sheets/item/tabs/description.hbs
-      slots=slots
       isPhysical=true}}
+      {{#if isOwned}}
+      <div class="side-property">
+        <label for="gear.container.select">{{localize 'TB2.GearContainedInLabel'}}</label>
+        <select id="gear.container.select" name="data.containedIn" data-type="String">
+          <option disabled {{#if (isEmpty data.data.containedIn)}}selected{{/if}}>{{localize "TB2.GearContainedInNothingLabel"}}</option>
+          {{#select data.data.containedIn}}
+            {{#each actor.data.data.containerSlots as |slotKey slotIdx|}}
+              {{log "slotKey:" slotKey}}
+              <option value="{{slotKey}}"
+                {{#if (compareItemSlot data.data.containedIn slotKey)}}selected{{/if}}
+              >{{localize slotKey}}</option>
+            {{/each}}
+          {{/select}}
+        </select>
+      </div>
+      {{/if}}
     {{/systems/torchbearer/templates/sheets/item/tabs/description.hbs}}
 
     {{!-- Effects Tab --}}
@@ -53,18 +68,20 @@
             name="data.availability"
             title="{{localize 'TB2.GearAvailabilityInput'}}"
             value="{{data.data.availability}}">
-          <label>{{localize 'TB2.GearBookNameLabel'}}</label>
-          <input
-            class="tb-embedded-document-list__editable change-item"
-            type="text" data-type="String"
-            name="data.bookName"
-            value="{{data.data.bookName}}">
-          <label for="data.page-{{data._id}}">{{localize 'TB2.GearBookPageLabel'}}</label>
-          <input
-            class="tb-embedded-document-list__editable change-item"
-            type="text" data-type="String"
-            name="data.page"
-            value="{{data.data.page}}">
+          <label>{{localize 'TB2.GearBookNameLabel'}}
+            <input
+              class="tb-embedded-document-list__editable change-item"
+              type="text" data-type="String"
+              name="data.bookName"
+              value="{{data.data.bookName}}">
+          </label>
+          <label>{{localize 'TB2.GearBookPageLabel'}}
+            <input
+              class="tb-embedded-document-list__editable change-item"
+              type="text" data-type="String"
+              name="data.page"
+              value="{{data.data.page}}">
+          </label>
         </div>
       {{> systems/torchbearer/templates/sheets/item/components/gear-slots.hbs}}
     {{/systems/torchbearer/templates/sheets/item/tabs/configuration.hbs}}

--- a/src/templates/sheets/item/gear-sheet.hbs
+++ b/src/templates/sheets/item/gear-sheet.hbs
@@ -26,22 +26,6 @@
     {{!-- Description Tab --}}
     {{#> systems/torchbearer/templates/sheets/item/tabs/description.hbs
       isPhysical=true}}
-      {{#if isOwned}}
-      <div class="side-property">
-        <label for="gear.container.select">{{localize 'TB2.GearContainedInLabel'}}</label>
-        <select id="gear.container.select" name="data.containedIn" data-type="String">
-          <option disabled {{#if (isEmpty data.data.containedIn)}}selected{{/if}}>{{localize "TB2.GearContainedInNothingLabel"}}</option>
-          {{#select data.data.containedIn}}
-            {{#each actor.data.data.containerSlots as |slotKey slotIdx|}}
-              {{log "slotKey:" slotKey}}
-              <option value="{{slotKey}}"
-                {{#if (compareItemSlot data.data.containedIn slotKey)}}selected{{/if}}
-              >{{localize slotKey}}</option>
-            {{/each}}
-          {{/select}}
-        </select>
-      </div>
-      {{/if}}
     {{/systems/torchbearer/templates/sheets/item/tabs/description.hbs}}
 
     {{!-- Effects Tab --}}
@@ -61,7 +45,7 @@
             name="data.cost"
             title="{{localize 'TB2.GearCostInput'}}"
             value="{{data.data.cost}}">
-          <label for="data.cost-{{data._id}}">{{localize 'TB2.GearAvailabilityLabel'}}</label>
+            <label for="data.cost-{{data._id}}">{{localize 'TB2.GearAvailabilityLabel'}}</label>
           <input
             class="tb-embedded-document-list__editable change-item"
             type="text" data-type="String"

--- a/src/templates/sheets/item/gear-sheet.hbs
+++ b/src/templates/sheets/item/gear-sheet.hbs
@@ -45,7 +45,7 @@
             name="data.cost"
             title="{{localize 'TB2.GearCostInput'}}"
             value="{{data.data.cost}}">
-            <label for="data.cost-{{data._id}}">{{localize 'TB2.GearAvailabilityLabel'}}</label>
+          <label for="data.cost-{{data._id}}">{{localize 'TB2.GearAvailabilityLabel'}}</label>
           <input
             class="tb-embedded-document-list__editable change-item"
             type="text" data-type="String"

--- a/src/templates/sheets/item/tabs/description.hbs
+++ b/src/templates/sheets/item/tabs/description.hbs
@@ -25,15 +25,33 @@ Additional elements of the side-properties div can be handed over via the @parti
                       class="fas fa-user"></i>{{actor.name}}</a>
           </div>
           {{#if isPhysical}}
-          <div class="side-property">
-              <label for="data.quantity">{{localize 'TB2.Quantity'}}</label>
-              <input type="number" min="0" step="1" data-dtype="Number" name="data.quantity"
-                  value="{{data.data.quantity}}" />
-          </div>
-          <div class="side-property">
-              <label for="data.storageLocation">{{localize 'TB2.StorageLocation'}}</label>
-              <input type="text" data-dtype="String" name="data.storageLocation" value="{{data.data.storageLocation}}" />
-          </div>
+            <div class="side-property">
+              <label for="data.containedIn">{{localize 'TB2.GearContainedInLabel'}}</label>
+              <div class="form-group">
+                <div class="form-fields">
+                  <select id="data.containedIn" name="container" data-type="String">
+                    {{log 'slots are' actor.data.data.containerSlots}}
+                    {{#select actor.data.data.containerSlots}}
+                      {{#each slot as |slotValue slotKey|}}
+                        {{log 'slot is' slot}}
+                        <option value="{{slotKey}}"
+                        {{#if compareItemSlot data.data.containedIn slotKey}}selected{{/if}}
+                        >{{localize slotValue}}</option>
+                      {{/each}}
+                    {{/select}}
+                  </select>
+                </div>
+              </div>
+            </div>
+<!--          <div class="side-property">-->
+<!--              <label for="data.quantity">{{localize 'TB2.Quantity'}}</label>-->
+<!--              <input type="number" min="0" step="1" data-dtype="Number" name="data.quantity"-->
+<!--                  value="{{data.data.quantity}}" />-->
+<!--          </div>-->
+<!--          <div class="side-property">-->
+<!--              <label for="data.storageLocation">{{localize 'TB2.StorageLocation'}}</label>-->
+<!--              <input type="text" data-dtype="String" name="data.storageLocation" value="{{data.data.storageLocation}}" />-->
+<!--          </div>-->
           {{/if}}
         {{else}}
           <span>{{localize "TB2.NotOwned"}}</span>

--- a/src/templates/sheets/item/tabs/description.hbs
+++ b/src/templates/sheets/item/tabs/description.hbs
@@ -25,24 +25,6 @@ Additional elements of the side-properties div can be handed over via the @parti
                       class="fas fa-user"></i>{{actor.name}}</a>
           </div>
           {{#if isPhysical}}
-            <div class="side-property">
-              <label for="data.containedIn">{{localize 'TB2.GearContainedInLabel'}}</label>
-              <div class="form-group">
-                <div class="form-fields">
-                  <select id="data.containedIn" name="container" data-type="String">
-                    {{log 'slots are' actor.data.data.containerSlots}}
-                    {{#select actor.data.data.containerSlots}}
-                      {{#each slot as |slotValue slotKey|}}
-                        {{log 'slot is' slot}}
-                        <option value="{{slotKey}}"
-                        {{#if compareItemSlot data.data.containedIn slotKey}}selected{{/if}}
-                        >{{localize slotValue}}</option>
-                      {{/each}}
-                    {{/select}}
-                  </select>
-                </div>
-              </div>
-            </div>
 <!--          <div class="side-property">-->
 <!--              <label for="data.quantity">{{localize 'TB2.Quantity'}}</label>-->
 <!--              <input type="number" min="0" step="1" data-dtype="Number" name="data.quantity"-->


### PR DESCRIPTION
basic inventory model:
a gear-type Item can be contained in a slot.
slots are an enum for the different types (pack, torso, head, etc.)
an actor can have any number of slots of each type.
gear is grouped by containing slot and displayed on the actor's inventory tab
gear newly assigned to an actor does not have a slot and must be assigned one (ghostGear). this is rendered below the slots described above.

future work:
- drag and drop between slots
- conditional highlighting / user warning if an actor's slot is over capacity
- container items (backpack, chests) are usually just "pack" slots, we will need to assign an item to a specific container, which is another item